### PR TITLE
add missing default png value for deprecated read_model() argument

### DIFF
--- a/R/read_model.R
+++ b/R/read_model.R
@@ -149,8 +149,6 @@ read_model <- function(
         "is forced internally in sa4ss::read_model()."
       )
     )
-  } else {
-    png = TRUE
   }
   if (lifecycle::is_present(html)) {
     lifecycle::deprecate_soft(
@@ -221,7 +219,6 @@ read_model <- function(
         fleetnames = model$FleetNames
     }
     r4ss::SS_plots(replist = model,
-                   png = png,
                    html = FALSE,
                    datplot = TRUE,
                    fleetnames = fleetnames,

--- a/R/read_model.R
+++ b/R/read_model.R
@@ -149,6 +149,8 @@ read_model <- function(
         "is forced internally in sa4ss::read_model()."
       )
     )
+  } else {
+    png = TRUE
   }
   if (lifecycle::is_present(html)) {
     lifecycle::deprecate_soft(


### PR DESCRIPTION
I was getting this error
```
r$> sa4ss::read_model(mod_loc = mod$inputs$dir, save_loc = file.path(getwd(), "doc"))
Error in pdf & png : 
  operations are possible only for numeric, logical or complex types
```
which I tracked down to `sa4ss::read_model()` passing a symbol for the `png` argument to to `r4ss::SS_plots()`:
```
r$> sa4ss::read_model(mod_loc = mod$inputs$dir, save_loc = file.path(getwd(), "doc"))
Called from: sa4ss::read_model(mod_loc = mod$inputs$dir, save_loc = file.path(getwd(),
    "doc"))

Browse[1]> png


Browse[1]> str(png)
 symbol
```

This PR fixed the problem, but feel free to implement some other way.